### PR TITLE
Updated power output names and symbols

### DIFF
--- a/core/class/Nut_free.class.php
+++ b/core/class/Nut_free.class.php
@@ -89,7 +89,7 @@ class Nut_free extends eqLogic {
 			'name' =>'Puissance en sortie',
 			'logicalId'=>'output_power',
 			'cmd'=>'ups.power',
-			'unite'=>'W',
+			'unite'=>'VA',
 		),
 		array(
 			'name' =>'Puissance en sortie réel',

--- a/core/template/dashboard/Nut_free.html
+++ b/core/template/dashboard/Nut_free.html
@@ -98,7 +98,7 @@
 	
 	<div class="tooltips"  data-cmd_id="#output_powerid#" style="margin-left:5px;display: #output_power_display#;">
 			<span title="Puissance de sortie (output_power)" style="width:15px;">Puissance de sortie: </span>
-			<span id="output_power#id#"></span><span> W</span>
+			<span id="output_power#id#"></span><span> VA</span>
 	</div>
 	<script>
 		if ('#cnx_ssh#' == 'OK' || '#cnx_ssh#' == 'No') {
@@ -107,7 +107,7 @@
     </script>
 	
 	<div class="tooltips"  data-cmd_id="#output_real_powerid#" style="margin-left:5px;display: #output_real_power_display#;">
-			<span title="Puissance de sortie (output_real_power)" style="width:15px;">Puissance de sortie: </span>
+			<span title="Puissance de sortie (output_real_power)" style="width:15px;">Puissance de sortie réel: </span>
 			<span id="output_real_power#id#"></span><span> W</span>
 	</div>
 	<script>

--- a/core/template/mobile/Nut_free.html
+++ b/core/template/mobile/Nut_free.html
@@ -24,7 +24,7 @@
 	</div>
 	<div class="cmd tooltips" style="margin-left:5px;display: #input_volt_display#;">
 			<span title="Tension d'entrée (input_volt)" style="min-width:15px;"></span>
-			<span>Tension d'entrée: #input_volt# v</span>
+			<span>Tension d'entrée: #input_volt# V</span>
 	</div>
 	
 	<div class="tooltips" style="margin-left:5px;display: #input_freq_display#;">
@@ -33,7 +33,7 @@
 	</div>
 	<div class="cmd tooltips" style="margin-left:5px;display: #output_volt_display#;">
 			<span title="Tension de sortie (output_volt)" style="min-width:15px;"></span>
-			<span>Tension de sortie: #output_volt# v</span>
+			<span>Tension de sortie: #output_volt# V</span>
 	</div>
 	
 	<div class="tooltips" style="margin-left:5px;display: #output_freq_display#;">
@@ -42,11 +42,11 @@
 	</div>
 	<div class="tooltips" style="margin-left:5px;display: #output_power_display#;">
 			<span title="Puissance de sortie (output_power)" style="width:15px;"></span>
-			<span>Puissance de sortie: #output_power# w</span>
+			<span>Puissance de sortie: #output_power# VA</span>
 	</div>
 	<div class="tooltips" style="margin-left:5px;display: #output_real_power_display#;">
 			<span title="Puissance de sortie (output_real_power)" style="width:15px;"></span>
-			<span>Puissance de sortie: #output_real_power# w</span>
+			<span>Puissance de sortie réel: #output_real_power# W</span>
 	</div>
 	<div class="tooltips" style="margin-left:5px;display: #batt_charge_display#;">
 			<span title="Niveau de charge batterie (batt_charge)" style="width:15px;"></span>
@@ -54,7 +54,7 @@
 	</div>
 	<div class="tooltips" style="margin-left:5px;display: #batt_volt_display#;">
 			<span title="Tension de la batterie (batt_charge)" style="width:15px;"></span>
-			<span>Tension de la batterie: #batt_volt# v</span>
+			<span>Tension de la batterie: #batt_volt# V</span>
 	</div>
 	<div class="tooltips" style="margin-left:5px;display: #batt_temp_display#;">
 			<span title="Température de la batterie (batt_temp)" style="width:15px;"></span>


### PR DESCRIPTION
This PR changes a few of the symbols and names used by the widget and the commands to resolve some discrepancies. The other things which got changed is the symbol for the normal power output which is in VA and not W.